### PR TITLE
Update depricated PHP constuctor declaration

### DIFF
--- a/woocommerce-invoicefox/lib/invfoxapi.php
+++ b/woocommerce-invoicefox/lib/invfoxapi.php
@@ -3,7 +3,7 @@ class InvfoxAPI {
 
   var $api;
 
-  function InvfoxAPI($apitoken, $apidomain, $debugMode=false) {
+  function __construct($apitoken, $apidomain, $debugMode=false) {
     $this->api = new StrpcAPI($apitoken, $apidomain, $debugMode);
   }
 

--- a/woocommerce-invoicefox/lib/strpcapi.php
+++ b/woocommerce-invoicefox/lib/strpcapi.php
@@ -9,7 +9,7 @@ class StrpcAPI {
   
   static function trace($x) { echo $x; }
 
-  function StrpcAPI($token, $domain, $debugMode=false) {
+  function __construct($token, $domain, $debugMode=false) {
     $this->apitoken = $token;
     $this->domain = $domain;
     $this->debugMode = $debugMode;
@@ -62,7 +62,7 @@ class StrpcRes {
   
   var $res;
   
-  function StrpcRes($res) {
+  function __construct($res) {
     $this->res = $res;
   }
   


### PR DESCRIPTION
Wordpress was reporting the usage of depricated PHP class constructor declaration. This change uses __construct() instead of class_name()