### PR TITLE
Fixed an undefined variable - fixing PDF invoice attachments

### DIFF
--- a/woocommerce-invoicefox/functions.php
+++ b/woocommerce-invoicefox/functions.php
@@ -1,0 +1,29 @@
+<?php
+function my_theme_enqueue_styles() { 
+    wp_enqueue_style( 'parent-style', get_template_directory_uri() . '/style.css' );
+}
+add_action( 'wp_enqueue_scripts', 'my_theme_enqueue_styles' );
+
+function attach_file_woocommerce_email($attachments, $id, $object)
+{           
+    if($id == 'customer_completed_order')
+    {   
+        
+    try {
+        $str = "invoicefox_attached_pdf";
+        $updated_order = wc_get_order( $object->get_id());
+        $upload = $updated_order->get_meta($str, True);
+        error_log("Emailing invoice: ");
+        error_log($upload); 
+        $attachments[] = $upload;  
+
+     }
+    
+    catch (Exception $e) {
+        error_log($e->getMessage());
+     }
+    }
+
+    return $attachments;
+}
+add_filter('woocommerce_email_attachments', 'attach_file_woocommerce_email', 10, 3);

--- a/woocommerce-invoicefox/functions_example.php
+++ b/woocommerce-invoicefox/functions_example.php
@@ -1,4 +1,9 @@
 <?php
+
+# Example filter that attaches PDF invoices to emails
+# Should be part of your theme's functions.php  
+
+
 function my_theme_enqueue_styles() { 
     wp_enqueue_style( 'parent-style', get_template_directory_uri() . '/style.css' );
 }

--- a/woocommerce-invoicefox/lib/invfoxapi.php
+++ b/woocommerce-invoicefox/lib/invfoxapi.php
@@ -90,7 +90,7 @@ class InvfoxAPI {
         )
       );
     $context = stream_context_create($opts);
-    $data = file_get_contents("https://{$this->api->domain}/API-pdf?id=$id&extid=$extid&res={$res}&format=PDF&doctitle=Invoice%20No.&lang=si&hstyle={$hstyle}", false, $context);
+    $data = file_get_contents("https://{$this->api->domain}/API-pdf?id=$id&extid=$extid&res={$res}&format=PDF&doctitle=Račun%20št.&lang=si&hstyle={$hstyle}", false, $context);
 
     if ($data === false) {
       echo 'error downloading PDF';

--- a/woocommerce-invoicefox/readme
+++ b/woocommerce-invoicefox/readme
@@ -8,3 +8,6 @@ License: GPLv3 or later License
 URI: http://www.gnu.org/licenses/gpl-3.0.html
 WC requires at least: 3.8
 WC tested up to: 4.3
+
+Making PDF attachments work:
+	Include filter from functions_example.php in your theme's functions.php

--- a/woocommerce-invoicefox/readme
+++ b/woocommerce-invoicefox/readme
@@ -9,5 +9,8 @@ URI: http://www.gnu.org/licenses/gpl-3.0.html
 WC requires at least: 3.8
 WC tested up to: 4.3
 
-Making PDF attachments work:
+
+
+Making PDF attachments work (small modification to the original plugin was made in this branch):
+	Create a folder called invoices in wp-content/uploads/ and make sure PHP has the appropriate permissions to write in it!
 	Include filter from functions_example.php in your theme's functions.php

--- a/woocommerce-invoicefox/woocommerce-invoicefox.php
+++ b/woocommerce-invoicefox/woocommerce-invoicefox.php
@@ -406,7 +406,7 @@ if ( ! class_exists( 'WC_InvoiceFox' ) ) {
                         }
 
 						$uploads = wp_upload_dir();
-						$path    = $uploads['basedir'] . "/invoices";
+						$upload_path    = $uploads['basedir'] . "/invoices";
                         
 						//$filename = $api->downloadInvoicePDF( $order->id, $path );
 						$filename = $api->downloadPDF( 0, $order->id, $upload_path, 'invoice-sent', '' );

--- a/woocommerce-invoicefox/woocommerce-invoicefox.php
+++ b/woocommerce-invoicefox/woocommerce-invoicefox.php
@@ -437,8 +437,9 @@ if ( ! class_exists( 'WC_InvoiceFox' ) ) {
 						*/
 
 						add_post_meta( $order->id, 'invoicefox_attached_pdf', $filename );
-
+						$order->save();
 						$order->add_order_note( "Invoice No. {$r3[0]['new_title']} was created at {$this->conf['app_name']}." );
+
 					}
 
 				} elseif ( $this->conf['document_to_make'] == 'proforma' ) {


### PR DESCRIPTION
For PDF invoices to be downloaded wp-content/uploads/invoices **must exist**. I had to create it manually. I suggest said folder creation is implemented during plugin init.